### PR TITLE
P7 질문입니다

### DIFF
--- a/PA0-A/main.c
+++ b/PA0-A/main.c
@@ -59,7 +59,7 @@ void calc_area2(struct Point2 *P1, struct Point2 *P2, int *area)
 char* reverse(char *word)
 {
 	/* Fill this function */
-	return NULL;
+	return word;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
112행을 보면 printf()는 뒤집은 문자열(%s)을 reverse(word)를 통해 받습니다. 따라서 reverse()는 뒤집은 문자열을 char* 타입의 string으로 반환해야 한다고 생각합니다. 하지만 62행의 reverse() 정의를 보면 "return NULL"로 명시되어 있습니다. 그렇기에 reverse() 함수의 내용과 무관하게 NULL pointer를 반환하는 문제가 생길 것으로 추측됩니다.

제 추측이 맞다면 62행의 "return NULL;"을 "return word;"로 바꾸면 될 것이라 예상합니다. 학생들은 포인터를 이용해 word 변수에 바로 접근해서 뒤집은 문자열을 덮어쓸 수 있습니다. 그리고 reverse()함수가 word의 포인터를 반환하면 문제 없이 112행이 실행될 것이라고 생각합니다.

handout.pdf 파일에선 "나머지 함수를 채우시기 바랍니다"라고 되어 있어 저 처럼 주어진 62행을 건들지 않고 푸려는 학생이 있을 수 있다고 생각해 pull request 남깁니다. 감사합니다.